### PR TITLE
fix(ipam_driver): do not pass --ipam-driver option when value set to default

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project focuses on:
 This project only depends on:
 
 * `podman`
-* [podman dnsname plugin](https://github.com/containers/dnsname): It is usually found in the `podman-plugins` or `podman-dnsname` distro packages, those packages are not pulled by default and you need to install them. This allows containers to be able to resolve each other if they are on the same CNI network.
+* [podman dnsname plugin](https://github.com/containers/dnsname): It is usually found in the `podman-plugins` or `podman-dnsname` distro packages, those packages are not pulled by default and you need to install them. This allows containers to be able to resolve each other if they are on the same CNI network. This is not necessary when podman is using netavark as a network backend.
 * Python3
 * [PyYAML](https://pyyaml.org/)
 * [python-dotenv](https://pypi.org/project/python-dotenv/)

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ like `hostnet`. If you desire that behavior, pass it the standard way like `netw
 
 ## Installation
 
+### Pip
+
 Install the latest stable version from PyPI:
 
-```
+```bash
 pip3 install podman-compose
 ```
 
@@ -59,14 +61,33 @@ pass `--user` to install inside regular user home without being root.
 
 Or latest development version from GitHub:
 
-```
+```bash
 pip3 install https://github.com/containers/podman-compose/archive/devel.tar.gz
 ```
 
+### Homebrew
+
+```bash
+brew install podman-compose
+```
+
+### Manual
+
+```bash
+curl -o /usr/local/bin/podman-compose https://raw.githubusercontent.com/containers/podman-compose/devel/podman_compose.py
+chmod +x /usr/local/bin/podman-compose
+```
+
+or inside your home
+
+```bash
+curl -o ~/.local/bin/podman-compose https://raw.githubusercontent.com/containers/podman-compose/devel/podman_compose.py
+chmod +x ~/.local/bin/podman-compose
+```
 
 or install from Fedora (starting from f31) repositories:
 
-```
+```bash
 sudo dnf install podman-compose
 ```
 
@@ -75,10 +96,9 @@ sudo dnf install podman-compose
 We have included fully functional sample stacks inside `examples/` directory.
 You can get more examples from [awesome-compose](https://github.com/docker/awesome-compose).
 
-
 A quick example would be
 
-```
+```bash
 cd examples/busybox
 podman-compose --help
 podman-compose up --help

--- a/completion/bash/podman-compose
+++ b/completion/bash/podman-compose
@@ -267,7 +267,7 @@ _podmanCompose() {
     help_opts="-h --help"
 
     # global options that don't take additional arguments
-    basic_global_opts="${help_opts} -v --no-ansi --no-cleanup --dry-run" 
+    basic_global_opts="${help_opts} -v --no-ansi --no-cleanup --dry-run"
 
     # global options that take paths as arguments
     path_arg_global_opts="-f --file --podman-path"
@@ -291,7 +291,7 @@ _podmanCompose() {
     if [[ $? -eq 0 ]]; then
         return 0
     fi
-   
+
     # computing comp_cword_adj, which thruthfully tells us how deep in the subcommands tree we are
     # additionally, set the chosen_root_command if possible
     comp_cword_adj=${COMP_CWORD}
@@ -309,7 +309,7 @@ _podmanCompose() {
             fi
             if [[ ${el} == -* && ${el} != ${cur} ]]; then
                 let "comp_cword_adj--"
-                
+
                 for opt in ${arg_global_opts_array[@]}; do
                     if [[ ${el} == ${opt} ]]; then
                         skip_next="yes"
@@ -320,7 +320,7 @@ _podmanCompose() {
             fi
         done
     fi
-    
+
     if [[ ${comp_cword_adj} -eq 1 ]]; then
        _completeRoot
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1811,7 +1811,7 @@ class PodmanCompose:
         parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
         self._init_global_parser(parser)
         subparsers = parser.add_subparsers(title="command", dest="command")
-        subparser = subparsers.add_parser("help", help="show help")
+        _ = subparsers.add_parser("help", help="show help")
         for cmd_name, cmd in self.commands.items():
             subparser = subparsers.add_parser(
                 cmd_name, help=cmd.desc

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -10,24 +10,22 @@
 # TODO: podman pod logs --color -n -f pod_testlogs
 
 
-import sys
-import os
-import getpass
 import argparse
-import itertools
-import subprocess
-import time
-import re
-import hashlib
-import random
-import json
+import getpass
 import glob
-from typing import Optional, Sequence
+import hashlib
+import itertools
+import json
 import logging
-
-from threading import Thread
-
+import os
+import random
+import re
 import shlex
+import subprocess
+import sys
+import time
+from threading import Thread
+from typing import Optional, Sequence
 
 try:
     from shlex import quote as cmd_quote
@@ -576,7 +574,7 @@ def get_secret_args(compose, cnt, secret):
         volume_ref = ["--volume", f"{source_file}:{dest_file}:ro,rprivate,rbind"]
         if uid or gid or mode:
             sec = target if target else secret_name
-            log.warn(
+            log.warning(
                 f'WARNING: Service {cnt["_service"]} uses secret "{sec}" with uid, gid, or mode.'
                 + " These fields are not supported by this implementation of the Compose file"
             )
@@ -604,7 +602,7 @@ def get_secret_args(compose, cnt, secret):
         if target and target != secret_name:
             raise ValueError(err_str.format(target, secret_name))
         if target:
-            log.warn(
+            log.warning(
                 'WARNING: Service "{}" uses target: "{}" for secret: "{}".'.format(
                     cnt["_service"], target, secret_name
                 )
@@ -962,7 +960,7 @@ def container_to_args(compose, cnt, detached=True, extra_hosts=True):
         podman_args.extend(get_secret_args(compose, cnt, secret))
     if extra_hosts:
         for i in cnt.get("extra_hosts", []):
-            podman_args.extend(["--add-host", i]
+            podman_args.extend(["--add-host", i])
     for i in cnt.get("expose", []):
         podman_args.extend(["--expose", i])
     if cnt.get("publishall", None):
@@ -1080,7 +1078,7 @@ def container_to_args(compose, cnt, detached=True, extra_hosts=True):
 
     rootfs = cnt.get("rootfs", None)
     if rootfs is not None:
-        podman_args.extend(["--rootfs", cnt['rootfs']])
+        podman_args.extend(["--rootfs", cnt["rootfs"]])
     else:
         podman_args.append(cnt["image"])  # command, ..etc.
     command = cnt.get("command", None)
@@ -1289,7 +1287,7 @@ def normalize_service(service, sub_dir=""):
         if is_list(deps):
             deps_dict = dict()
             for d in deps:
-                deps_dict[d] = {'condition': 'service_started'}
+                deps_dict[d] = {"condition": "service_started"}
             service["depends_on"] = deps_dict
     return service
 
@@ -1481,7 +1479,7 @@ class PodmanCompose:
         missing = given - self.all_services
         if missing:
             missing_csv = ",".join(missing)
-            log.warn(f"missing services [{missing_csv}]")
+            log.warning(f"missing services [{missing_csv}]")
             sys.exit(1)
 
     def get_podman_args(self, cmd):
@@ -1665,7 +1663,7 @@ class PodmanCompose:
         services = compose.get("services", None)
         if services is None:
             services = {}
-            log.warn("WARNING: No services defined")
+            log.warning("WARNING: No services defined")
         # include services with no profile defined or the selected profiles
         services = self._resolve_profiles(services, set(args.profile))
 
@@ -1704,7 +1702,7 @@ class PodmanCompose:
         unused_nets = given_nets - allnets - set(["default"])
         if len(unused_nets):
             unused_nets_str = ",".join(unused_nets)
-            log.warn(f"WARNING: unused networks: {unused_nets_str}")
+            log.warning(f"WARNING: unused networks: {unused_nets_str}")
         if len(missing_nets):
             missing_nets_str = ",".join(missing_nets)
             raise RuntimeError(f"missing networks: {missing_nets_str}")
@@ -1825,7 +1823,7 @@ class PodmanCompose:
             parser.print_help()
             sys.exit(-1)
 
-        logging.basicConfig(level=('DEBUG' if self.global_args.verbose else 'WARN'))
+        logging.basicConfig(level=("DEBUG" if self.global_args.verbose else "WARN"))
         return self.global_args
 
     @staticmethod
@@ -1968,9 +1966,19 @@ class cmd_parse:  # pylint: disable=invalid-name,too-few-public-methods
 # Thread used to start containers in a compose project. This thread keeps track of the corresponding container name
 # and the service name
 class _ContainerStartThread(Thread):
-    def __init__(self, service_name, container_name, target=None, name=None,
-                 args=(), kwargs=None, daemon=None):
-        super().__init__(target=target, name=name, args=args, kwargs=kwargs, daemon=daemon)
+    def __init__(
+        self,
+        service_name,
+        container_name,
+        target=None,
+        name=None,
+        args=(),
+        kwargs=None,
+        daemon=None,
+    ):
+        super().__init__(
+            target=target, name=name, args=args, kwargs=kwargs, daemon=daemon
+        )
         self._service_name = service_name
         self._container_name = container_name
 
@@ -2090,10 +2098,10 @@ ExecStop=/usr/bin/podman pod stop pod_%i
 WantedBy=default.target
 """
         if os.access(os.path.dirname(fn), os.W_OK):
-            log.debug(f"writing [{fn}]: ...")
+            log.debug("writing [%s]: ...", fn)
             with open(fn, "w", encoding="utf-8") as f:
                 f.write(out)
-            log.debug(f"writing [{fn}]: done.")
+            log.debug("writing [%s]: done.", fn)
             print(
                 """
 while in your project type `podman-compose systemd -a register`
@@ -2101,7 +2109,7 @@ while in your project type `podman-compose systemd -a register`
             )
         else:
             print(out)
-            log.warn(f"Could not write to [{fn}], use 'sudo'")
+            log.warning("Could not write to [%s], use 'sudo'", fn)
 
 
 @cmd_run(podman_compose, "pull", "pull stack images")
@@ -2298,7 +2306,9 @@ def compose_up(compose, args):
         if cnt["_service"] in excluded:
             log.debug("** skipping: %s", cnt["name"])
             continue
-        podman_args = container_to_args(compose, cnt, detached=args.detach, extra_hosts=args.extra_hosts)
+        podman_args = container_to_args(
+            compose, cnt, detached=args.detach, extra_hosts=args.extra_hosts
+        )
         subproc = compose.podman.run([], podman_command, podman_args)
         if podman_command == "run" and subproc and subproc.returncode:
             compose.podman.run([], "start", [cnt["name"]])
@@ -2363,11 +2373,18 @@ def compose_up(compose, args):
                     exit_code = (
                         compose.exit_code if compose.exit_code is not None else -1
                     )
-                    log("aborting because container:", thread.container_name, "exited with exit code:", exit_code)
+                    log(
+                        "aborting because container:",
+                        thread.container_name,
+                        "exited with exit code:",
+                        exit_code,
+                    )
                     # stop other containers that were launched
                     default_stop_timeout = getattr(args, "timeout", None)
                     to_stop = launched_container_names
-                    to_stop.remove(thread.container_name)  # no need to attempt stopping this already exited container
+                    to_stop.remove(
+                        thread.container_name
+                    )  # no need to attempt stopping this already exited container
                     _stop_containers(compose, to_stop, default_stop_timeout)
         for thread in to_remove:
             threads.remove(thread)
@@ -2998,13 +3015,12 @@ def compose_up_parse(parser):
         help="Return the exit code of the selected service container. Implies --abort-on-container-exit.",
     )
     parser.add_argument(
-        "--disable-extra-hosts", 
+        "--disable-extra-hosts",
         dest="extra_hosts",
-        action='store_false',
+        action="store_false",
         default=True,
-        help="Don't pass --add-host when starting containers. Fixes: https://github.com/containers/podman/issues/15373"
+        help="Don't pass --add-host when starting containers. Fixes: https://github.com/containers/podman/issues/15373",
     )
-
 
 
 @cmd_parse(podman_compose, "down")

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -402,13 +402,9 @@ def assert_volume(compose, mount_dict):
         if is_ext:
             raise RuntimeError(f"External volume [{vol_name}] does not exists") from e
         labels = vol.get("labels", None) or []
-        args = [
-            "create",
-            "--label",
-            f"io.podman.compose.project={proj_name}",
-            "--label",
-            f"com.docker.compose.project={proj_name}",
-        ]
+        args = ["create"]
+        if not compose.global_args.no_label:
+            args.extend(["--label", f"io.podman.compose.project={proj_name}"])
         for item in norm_as_list(labels):
             args.extend(["--label", item])
         driver = vol.get("driver", None)
@@ -738,13 +734,9 @@ def assert_cnt_nets(compose, cnt):
                 raise RuntimeError(
                     f"External network [{net_name}] does not exists"
                 ) from e
-            args = [
-                "create",
-                "--label",
-                f"io.podman.compose.project={proj_name}",
-                "--label",
-                f"com.docker.compose.project={proj_name}",
-            ]
+            args = ["create"]
+            if not compose.global_args.no_label:
+                args.extend(["--label", f"io.podman.compose.project={proj_name}"])
             # TODO: add more options here, like dns, ipv6, etc.
             labels = net_desc.get("labels", None) or []
             for item in norm_as_list(labels):
@@ -1718,15 +1710,15 @@ class PodmanCompose:
             raise RuntimeError(f"missing networks: {missing_nets_str}")
         # volumes: [...]
         self.vols = compose.get("volumes", {})
-        podman_compose_labels = [
-            "io.podman.compose.config-hash=" + self.yaml_hash,
-            "io.podman.compose.project=" + project_name,
-            "io.podman.compose.version=" + __version__,
-            f"PODMAN_SYSTEMD_UNIT=podman-compose@{project_name}.service",
-            "com.docker.compose.project=" + project_name,
-            "com.docker.compose.project.working_dir=" + dirname,
-            "com.docker.compose.project.config_files=" + ",".join(relative_files),
-        ]
+        if self.global_args.no_label:
+            podman_compose_labels = []
+        else:
+            podman_compose_labels = [
+                "io.podman.compose.version=" + __version__,
+                "io.podman.compose.config-hash=" + self.yaml_hash,
+                "io.podman.compose.project=" + project_name,
+                "io.podman.compose.project.config_files=" + ",".join(relative_files),
+            ]
         # other top-levels:
         # networks: {driver: ...}
         # configs: {...}
@@ -1756,12 +1748,13 @@ class PodmanCompose:
                 labels = norm_as_list(cnt.get("labels", None))
                 cnt["ports"] = norm_ports(cnt.get("ports", None))
                 labels.extend(podman_compose_labels)
-                labels.extend(
-                    [
-                        f"com.docker.compose.container-number={num}",
-                        "com.docker.compose.service=" + service_name,
-                    ]
-                )
+                if not self.global_args.no_label:
+                    labels.extend(
+                        [
+                            f"io.podman.compose.container-number={num}",
+                            f"io.podman.compose.service={service_name}",
+                        ]
+                    )
                 cnt["labels"] = labels
                 cnt["_service"] = service_name
                 cnt["_project"] = project_name
@@ -1908,6 +1901,11 @@ class PodmanCompose:
         parser.add_argument(
             "--no-cleanup",
             help="Do not stop and remove existing pod & containers",
+            action="store_true",
+        )
+        parser.add_argument(
+            "--no-label",
+            help="disable default labels",
             action="store_true",
         )
         parser.add_argument(

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2784,6 +2784,48 @@ def compose_kill(compose, args):
         compose.podman.run([], "kill", podman_args)
 
 
+@cmd_run(podman_compose, "images", "List images used by the created containers")
+def compose_images(compose, args):
+    img_containers = [cnt for cnt in compose.containers if "image" in cnt]
+    data = []
+    if args.quiet is True:
+        for img in img_containers:
+            name = img["name"]
+            data.append(
+                compose.podman.output([], "images", ["--quiet", img["image"]])
+                .decode("utf-8")
+                .split()
+            )
+    else:
+        data.append(["CONTAINER", "REPOSITORY", "TAG", "IMAGE ID", "SIZE", ""])
+        for img in img_containers:
+            name = img["name"]
+            data.append(
+                compose.podman.output(
+                    [],
+                    "images",
+                    [
+                        "--format",
+                        "table " + name + " {{.Repository}} {{.Tag}} {{.ID}} {{.Size}}",
+                        "-n",
+                        img["image"],
+                    ],
+                )
+                .decode("utf-8")
+                .split()
+            )
+
+    # Determine the maximum length of each column
+    column_widths = [max(map(len, column)) for column in zip(*data)]
+
+    # Print each row
+    for row in data:
+        # Format each cell using the maximum column width
+        formatted_row = [cell.ljust(width) for cell, width in zip(row, column_widths)]
+        formatted_row[-2:] = ["".join(formatted_row[-2:]).strip()]
+        print("\t".join(formatted_row))
+
+
 @cmd_run(
     podman_compose,
     "stats",
@@ -3270,6 +3312,13 @@ def compose_kill_parse(parser):
         "--all",
         help="Signal all running containers",
         action="store_true",
+    )
+
+
+@cmd_parse(podman_compose, "images")
+def compose_images_parse(parser):
+    parser.add_argument(
+        "-q", "--quiet", help="Only display images IDs", action="store_true"
     )
 
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2511,7 +2511,8 @@ def compose_run(compose, args):
         if args.rm:
             podman_args.insert(1, "--rm")
     p = compose.podman.run([], "run", podman_args, sleep=0)
-    sys.exit(p.returncode)
+    if p:
+        sys.exit(p.returncode)
 
 
 @cmd_run(podman_compose, "exec", "execute a command in a running container")

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1814,7 +1814,7 @@ class PodmanCompose:
         _ = subparsers.add_parser("help", help="show help")
         for cmd_name, cmd in self.commands.items():
             subparser = subparsers.add_parser(
-                cmd_name, help=cmd.desc
+                cmd_name, help=cmd.help, description=cmd.desc
             )  # pylint: disable=protected-access
             for cmd_parser in cmd._parse_args:  # pylint: disable=protected-access
                 cmd_parser(subparser)
@@ -1939,7 +1939,13 @@ class cmd_run:  # pylint: disable=invalid-name,too-few-public-methods
 
         wrapped._compose = self.compose
         # Trim extra indentation at start of multiline docstrings.
-        wrapped.desc = self.cmd_desc or re.sub(r"^\s+", "", func.__doc__)
+        help_desc = self.cmd_desc or re.sub(r"^\s+", "", func.__doc__)
+        if "\n" in help_desc:
+            wrapped.help, wrapped.desc = help_desc.split("\n", 1)
+        else:
+            wrapped.help = help_desc
+            wrapped.desc = None
+
         wrapped._parse_args = []
         self.compose.commands[self.cmd_name] = wrapped
         return wrapped

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -992,8 +992,18 @@ def container_to_args(compose, cnt, detached=True, extra_hosts=True):
         podman_args.append("-i")
     if cnt.get("stop_signal", None):
         podman_args.extend(["--stop-signal", cnt["stop_signal"]])
-    for i in cnt.get("sysctls", []):
-        podman_args.extend(["--sysctl", i])
+
+    sysctls = cnt.get("sysctls")
+    if sysctls is not None:
+        if isinstance(sysctls, dict):
+            for sysctl, value in sysctls.items():
+                podman_args.extend(["--sysctl", "{}={}".format(sysctl, value)])
+        elif isinstance(sysctls, list):
+            for i in sysctls:
+                podman_args.extend(["--sysctl", i])
+        else:
+            raise TypeError("sysctls should be either dict or list")
+
     if cnt.get("tty", None):
         podman_args.append("--tty")
     if cnt.get("privileged", None):

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1959,6 +1959,24 @@ class cmd_parse:  # pylint: disable=invalid-name,too-few-public-methods
         return wrapped
 
 
+# Thread used to start containers in a compose project. This thread keeps track of the corresponding container name
+# and the service name
+class _ContainerStartThread(Thread):
+    def __init__(self, service_name, container_name, target=None, name=None,
+                 args=(), kwargs=None, daemon=None):
+        super().__init__(target=target, name=name, args=args, kwargs=kwargs, daemon=daemon)
+        self._service_name = service_name
+        self._container_name = container_name
+
+    @property
+    def service_name(self):
+        return self._service_name
+
+    @property
+    def container_name(self):
+        return self._container_name
+
+
 ###################
 # actual commands
 ###################
@@ -2293,6 +2311,7 @@ def compose_up(compose, args):
             curr_length if curr_length > max_service_length else max_service_length
         )
     has_sed = os.path.isfile("/bin/sed")
+    launched_container_names = []  # keep track of containers that we attempted to start
     for i, cnt in enumerate(compose.containers):
         # Add colored service prefix to output by piping output through sed
         color_idx = i % len(compose.console_colors)
@@ -2306,8 +2325,10 @@ def compose_up(compose, args):
             log.debug("** skipping: %s", cnt["name"])
             continue
         # TODO: remove sleep from podman.run
-        obj = compose if exit_code_from == cnt["_service"] else None
-        thread = Thread(
+        obj = compose if args.abort_on_container_exit else None
+        thread = _ContainerStartThread(
+            cnt["_service"],
+            cnt["name"],
             target=compose.podman.run,
             args=[[], "start", ["-a", cnt["name"]]],
             kwargs={"obj": obj, "log_formatter": log_formatter},
@@ -2316,22 +2337,67 @@ def compose_up(compose, args):
         )
         thread.start()
         threads.append(thread)
+        launched_container_names.append(cnt["name"])
         time.sleep(1)
 
+    exit_code = None
+    abort_sequence_started = False
     while threads:
         to_remove = []
         for thread in threads:
             thread.join(timeout=1.0)
             if not thread.is_alive():
                 to_remove.append(thread)
-                if args.abort_on_container_exit:
-                    time.sleep(1)
+                if args.abort_on_container_exit and not abort_sequence_started:
+                    abort_sequence_started = True
+                    # keep track of the exit code of the container that triggered the abort
                     exit_code = (
                         compose.exit_code if compose.exit_code is not None else -1
                     )
-                    sys.exit(exit_code)
+                    log("aborting because container:", thread.container_name, "exited with exit code:", exit_code)
+                    # stop other containers that were launched
+                    default_stop_timeout = getattr(args, "timeout", None)
+                    to_stop = launched_container_names
+                    to_stop.remove(thread.container_name)  # no need to attempt stopping this already exited container
+                    _stop_containers(compose, to_stop, default_stop_timeout)
         for thread in to_remove:
             threads.remove(thread)
+    if abort_sequence_started and exit_code is not None:
+        log("aborting with exit code:", exit_code)
+        sys.exit(exit_code)
+
+
+def _stop_containers(compose, to_stop, default_timeout=None):
+    if to_stop is None or len(to_stop) == 0:
+        return
+    """
+        Stops the containers belonging to the project
+
+        Args:
+            compose (PodmanCompose): PodmanCompose instance
+            to_stop (list): A list of container names which should be stopped.
+            default_timeout (int): In the absence of a stop_grace_period for the container being stopped,
+                    this is the default timeout that will be passed to the "stop" command
+                    while stopping the container.
+        Returns:
+            A list of container names that were stopped
+    """
+    stopped_containers = []
+    containers = list(reversed(compose.containers))  # stop in reverse order
+    for cnt in containers:
+        if cnt["name"] not in to_stop:
+            continue  # skip stopping
+        podman_stop_args = []
+        timeout = default_timeout
+        if timeout is None:
+            timeout_str = cnt.get("stop_grace_period", None) or STOP_GRACE_PERIOD
+            timeout = str_to_seconds(timeout_str)
+        if timeout is not None:
+            podman_stop_args.extend(["-t", str(timeout)])
+        log("stopping container: ", cnt["name"])
+        compose.podman.run([], "stop", [*podman_stop_args, cnt["name"]], sleep=0)
+        stopped_containers.append(cnt["name"])
+    return stopped_containers
 
 
 def get_volume_names(compose, cnt):

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1008,6 +1008,8 @@ def container_to_args(compose, cnt, detached=True, extra_hosts=True):
         podman_args.append("--tty")
     if cnt.get("privileged", None):
         podman_args.append("--privileged")
+    if cnt.get("pid", None):
+        podman_args.extend("--pid", cnt["pid"])
     pull_policy = cnt.get("pull_policy", None)
     if pull_policy is not None and pull_policy != "build":
         podman_args.extend(["--pull", pull_policy])

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2784,6 +2784,37 @@ def compose_kill(compose, args):
         compose.podman.run([], "kill", podman_args)
 
 
+@cmd_run(
+    podman_compose,
+    "stats",
+    "Display percentage of CPU, memory, network I/O, block I/O and PIDs for services.",
+)
+def compose_stats(compose, args):
+    container_names_by_service = compose.container_names_by_service
+    if not args.services:
+        args.services = container_names_by_service.keys()
+    targets = []
+    podman_args = []
+    if args.interval:
+        podman_args.extend(["--interval", args.interval])
+    if args.format:
+        podman_args.extend(["--format", args.format])
+    if args.no_reset:
+        podman_args.append("--no-reset")
+    if args.no_stream:
+        podman_args.append("--no-stream")
+
+    for service in args.services:
+        targets.extend(container_names_by_service[service])
+    for target in targets:
+        podman_args.append(target)
+
+    try:
+        compose.podman.run([], "stats", podman_args)
+    except KeyboardInterrupt:
+        pass
+
+
 @cmd_run(podman_compose, "images", "List images used by the created containers")
 def compose_images(compose, args):
     img_containers = [cnt for cnt in compose.containers if "image" in cnt]
@@ -3311,6 +3342,35 @@ def compose_kill_parse(parser):
         "-a",
         "--all",
         help="Signal all running containers",
+        action="store_true",
+    )
+
+
+@cmd_parse(podman_compose, ["stats"])
+def compose_stats_parse(parser):
+    parser.add_argument(
+        "services", metavar="services", nargs="*", default=None, help="service names"
+    )
+    parser.add_argument(
+        "-i",
+        "--interval",
+        type=int,
+        help="Time in seconds between stats reports (default 5)",
+    )
+    parser.add_argument(
+        "-f",
+        "--format",
+        type=str,
+        help="Pretty-print container statistics to JSON or using a Go template",
+    )
+    parser.add_argument(
+        "--no-reset",
+        help="Disable resetting the screen between intervals",
+        action="store_true",
+    )
+    parser.add_argument(
+        "--no-stream",
+        help="Disable streaming stats and only pull the first result",
         action="store_true",
     )
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2126,7 +2126,9 @@ def compose_push(compose, args):
             continue
         if services and cnt["_service"] not in services:
             continue
-        compose.podman.run([], "push", [cnt["image"]], sleep=0)
+        exit_code = compose.podman.run([], "push", [cnt["image"]], sleep=0).wait()
+        if (not getattr(args, "ignore_push_failures", None)) and 0 != exit_code:
+            sys.exit(exit_code)
 
 
 def build_one(compose, args, cnt):
@@ -3236,7 +3238,7 @@ def compose_push_parse(parser):
     parser.add_argument(
         "--ignore-push-failures",
         action="store_true",
-        help="Push what it can and ignores images with push failures. (not implemented)",
+        help="Push what it can and ignores images with push failures.",
     )
     parser.add_argument(
         "services", metavar="services", nargs="*", help="services to push"

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2475,7 +2475,7 @@ def compose_run(compose, args):
     name0 = "{}_{}_tmp{}".format(
         compose.project_name, args.service, random.randrange(0, 65536)
     )
-    cnt["name"] = args.name or name0
+    cnt["name"] = args.name or container_name or name0
     if args.entrypoint:
         cnt["entrypoint"] = args.entrypoint
     if args.user:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2068,7 +2068,7 @@ def compose_systemd(compose, args):
                     f.write(f"{k}={v}\n")
         log.debug(f"writing [{fn}]: done.")
         log.info("\n\ncreating the pod without starting it: ...\n\n")
-        process = subprocess.run([script, "up", "--no-start"], check=False)
+        process = subprocess.run([script, "--in-pod", proj_name, "up", "--no-start"], check=False)
         log.info("\nfinal exit code is ", process.returncode)
         username = getpass.getuser()
         print(
@@ -2107,7 +2107,7 @@ Description=%i rootless pod (podman-compose)
 [Service]
 Type=simple
 EnvironmentFile=%h/{stacks_dir}/%i.env
-ExecStartPre=-{script} up --no-start
+ExecStartPre=-{script} --in-pod %i up --no-start
 ExecStartPre=/usr/bin/podman pod start pod_%i
 ExecStart={script} wait
 ExecStop=/usr/bin/podman pod stop pod_%i

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1602,8 +1602,8 @@ class PodmanCompose:
                 if key.startswith("PODMAN_")
             }
         )
-        self.environ = dict(os.environ)
-        self.environ.update(dotenv_dict)
+        self.environ = dotenv_dict
+        self.environ.update(dict(os.environ))
         # see: https://docs.docker.com/compose/reference/envvars/
         # see: https://docs.docker.com/compose/env-file/
         self.environ.update(

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2192,8 +2192,9 @@ def build_one(compose, args, cnt):
             )
         )
     build_args.append(ctx)
-    status = compose.podman.run([], "build", build_args, sleep=0)
-    return status
+    exit_code = compose.podman.run([], "build", build_args, sleep=0).wait()
+    if exit_code:
+        sys.exit(exit_code)
 
 
 @cmd_run(podman_compose, "build", "build stack images")

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1257,6 +1257,12 @@ def normalize_service(service, sub_dir=""):
             if not context:
                 context = "."
             service["build"]["context"] = context
+    if "build" in service and "additional_contexts" in service["build"]:
+        if is_dict(build["additional_contexts"]):
+            new_additional_contexts = []
+            for k, v in build["additional_contexts"].items():
+                new_additional_contexts.append(f"{k}={v}")
+            build["additional_contexts"] = new_additional_contexts
     for key in ("command", "entrypoint"):
         if key in service:
             if is_str(service[key]):
@@ -2178,6 +2184,8 @@ def build_one(compose, args, cnt):
         build_args.extend(get_secret_args(compose, cnt, secret))
     for tag in build_desc.get("tags", []):
         build_args.extend(["-t", tag])
+    for additional_ctx in build_desc.get("additional_contexts", {}):
+        build_args.extend([f"--build-context={additional_ctx}"])
     if "target" in build_desc:
         build_args.extend(["--target", build_desc["target"]])
     if "network" in build_desc:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1151,7 +1151,7 @@ def flat_deps(services, with_extends=False):
         for c in links_ls:
             if ":" in c:
                 dep_name, dep_alias = c.split(":")
-                if not "_aliases" in services[dep_name]:
+                if "_aliases" not in services[dep_name]:
                     services[dep_name]["_aliases"] = set()
                 services[dep_name]["_aliases"].add(dep_alias)
     for name, srv in services.items():

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2554,9 +2554,9 @@ def transfer_service_status(compose, args, action):
         targets.extend(container_names_by_service[service])
     if action in ["stop", "restart"]:
         targets = list(reversed(targets))
-    podman_args = []
     timeout_global = getattr(args, "timeout", None)
     for target in targets:
+        podman_args = []
         if action != "start":
             timeout = timeout_global
             if timeout is None:

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -937,6 +937,8 @@ def container_to_args(compose, cnt, detached=True, extra_hosts=True):
         podman_args.extend(["--annotation", a])
     if cnt.get("read_only", None):
         podman_args.append("--read-only")
+    if cnt.get("http_proxy", None) == False:
+        podman_args.append("--http-proxy=false")
     for i in cnt.get("labels", []):
         podman_args.extend(["--label", i])
     for c in cnt.get("cap_add", []):

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1054,6 +1054,8 @@ def container_to_args(compose, cnt, detached=True, extra_hosts=True):
     platform = cnt.get("platform", None)
     if platform is not None:
         podman_args.extend(["--platform", platform])
+    if cnt.get("runtime", None):
+        podman_args.extend(["--runtime", cnt["runtime"]])
 
     # WIP: healthchecks are still work in progress
     healthcheck = cnt.get("healthcheck", None) or {}

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -794,6 +794,8 @@ def get_net_args(compose, cnt):
             net_args.extend(["--network", net])
         elif net.startswith("slirp4netns:"):
             net_args.extend(["--network", net])
+        elif net.startswith("pasta"):
+            net_args.extend(["--network", net])
         elif net.startswith("ns:"):
             net_args.extend(["--network", net])
         elif net.startswith("service:"):

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1286,6 +1286,15 @@ def normalize_service(service, sub_dir=""):
         if is_str(extends):
             extends = {"service": extends}
             service["extends"] = extends
+    if "depends_on" in service:
+        deps = service["depends_on"]
+        if is_str(deps):
+            deps = [deps]
+        if is_list(deps):
+            deps_dict = dict()
+            for d in deps:
+                deps_dict[d] = {'condition': 'service_started'}
+            service["depends_on"] = deps_dict
     return service
 
 

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -22,6 +22,7 @@ import hashlib
 import random
 import json
 import glob
+from typing import Optional, Sequence
 import logging
 
 from threading import Thread
@@ -1498,9 +1499,9 @@ class PodmanCompose:
             xargs.extend(shlex.split(args))
         return xargs
 
-    def run(self):
+    def run(self, argv: Optional[Sequence[str]] = None):
         log.info("podman-compose version: " + __version__)
-        args = self._parse_args()
+        args = self._parse_args(argv)
         podman_path = args.podman_path
         if podman_path != "podman":
             if os.path.isfile(podman_path) and os.access(podman_path, os.X_OK):
@@ -1810,7 +1811,7 @@ class PodmanCompose:
                 services[name] = config
         return services
 
-    def _parse_args(self):
+    def _parse_args(self, argv: Optional[Sequence[str]] = None):
         parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter)
         self._init_global_parser(parser)
         subparsers = parser.add_subparsers(title="command", dest="command")
@@ -1821,7 +1822,7 @@ class PodmanCompose:
             )  # pylint: disable=protected-access
             for cmd_parser in cmd._parse_args:  # pylint: disable=protected-access
                 cmd_parser(subparser)
-        self.global_args = parser.parse_args()
+        self.global_args = parser.parse_args(argv)
         if self.global_args.version:
             self.global_args.command = "version"
         if not self.global_args.command or self.global_args.command == "help":

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -357,7 +357,7 @@ def norm_ulimit(inner_value):
 
 
 def transform(args, project_name, given_containers):
-    if not args.in_pod:
+    if args.no_pod:
         pod_name = None
         pods = []
     else:
@@ -1839,11 +1839,9 @@ class PodmanCompose:
     def _init_global_parser(parser):
         parser.add_argument("-v", "--version", help="show version", action="store_true")
         parser.add_argument(
-            "--in-pod",
-            help="pod creation",
-            metavar="in_pod",
-            type=lambda x: x.lower() in ["1", "true"],
-            default=True,
+            "--no-pod",
+            help="disable pod creation",
+            action="store_true",
         )
         parser.add_argument(
             "--pod-args",

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -542,7 +542,11 @@ def get_mount_args(compose, cnt, volume):
     return ["--mount", args]
 
 
-def get_secret_args(compose, cnt, secret):
+def get_secret_args(compose, cnt, secret, podman_is_building=False):
+    """
+    podman_is_building: True if we are preparing arguments for an invocation of "podman build"
+                        False if we are preparing for something else like "podman run"
+    """
     secret_name = secret if is_str(secret) else secret.get("source", None)
     if not secret_name or secret_name not in compose.declared_secrets.keys():
         raise ValueError(
@@ -560,18 +564,36 @@ def get_secret_args(compose, cnt, secret):
     mode = None if is_str(secret) else secret.get("mode", None)
 
     if source_file:
-        if not target:
-            dest_file = f"/run/secrets/{secret_name}"
-        elif not target.startswith("/"):
-            sec = target if target else secret_name
-            dest_file = f"/run/secrets/{sec}"
-        else:
-            dest_file = target
+        # assemble path for source file first, because we need it for all cases
         basedir = compose.dirname
         source_file = os.path.realpath(
             os.path.join(basedir, os.path.expanduser(source_file))
         )
-        volume_ref = ["--volume", f"{source_file}:{dest_file}:ro,rprivate,rbind"]
+
+        if podman_is_building:
+            # pass file secrets to "podman build" with param --secret
+            if not target:
+                secret_id = secret_name
+            elif "/" in target:
+                raise ValueError(
+                    f'ERROR: Build secret "{secret_name}" has invalid target "{target}". '
+                    + "(Expected plain filename without directory as target.)"
+                )
+            else:
+                secret_id = target
+
+            volume_ref = ["--secret", f"id={secret_id},src={source_file}"]
+        else:
+            # pass file secrets to "podman run" as volumes
+            if not target:
+                dest_file = f"/run/secrets/{secret_name}"
+            elif not target.startswith("/"):
+                sec = target if target else secret_name
+                dest_file = f"/run/secrets/{sec}"
+            else:
+                dest_file = target
+            volume_ref = ["--volume", f"{source_file}:{dest_file}:ro,rprivate,rbind"]
+
         if uid or gid or mode:
             sec = target if target else secret_name
             log.warning(
@@ -2193,7 +2215,9 @@ def build_one(compose, args, cnt):
         raise OSError("Dockerfile not found in " + ctx)
     build_args = ["-f", dockerfile, "-t", cnt["image"]]
     for secret in build_desc.get("secrets", []):
-        build_args.extend(get_secret_args(compose, cnt, secret))
+        build_args.extend(
+            get_secret_args(compose, cnt, secret, podman_is_building=True)
+        )
     for tag in build_desc.get("tags", []):
         build_args.extend(["-t", tag])
     for additional_ctx in build_desc.get("additional_contexts", {}):

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1082,7 +1082,11 @@ def container_to_args(compose, cnt, detached=True):
         for gidmap in x_podman.get("gidmaps", []):
             podman_args.extend(["--gidmap", gidmap])
 
-    podman_args.append(cnt["image"])  # command, ..etc.
+    rootfs = cnt.get("rootfs", None)
+    if rootfs is not None:
+        podman_args.extend(["--rootfs", cnt['rootfs']])
+    else:
+        podman_args.append(cnt["image"])  # command, ..etc.
     command = cnt.get("command", None)
     if command is not None:
         if is_str(command):
@@ -1734,7 +1738,7 @@ class PodmanCompose:
                     "service_name": service_name,
                     **service_desc,
                 }
-                if "image" not in cnt:
+                if "image" not in cnt and "rootfs" not in cnt:
                     cnt["image"] = f"{project_name}_{service_name}"
                 labels = norm_as_list(cnt.get("labels", None))
                 cnt["ports"] = norm_ports(cnt.get("ports", None))

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -1839,7 +1839,7 @@ class PodmanCompose:
             "--in-pod",
             help="pod creation",
             metavar="in_pod",
-            type=bool,
+            type=lambda x: x.lower() in ["1", "true"],
             default=True,
         )
         parser.add_argument(

--- a/podman_compose.py
+++ b/podman_compose.py
@@ -2148,6 +2148,8 @@ def build_one(compose, args, cnt):
         build_args.extend(["-t", tag])
     if "target" in build_desc:
         build_args.extend(["--target", build_desc["target"]])
+    if "network" in build_desc:
+        build_args.extend(["--network", build_desc["network"]])
     container_to_ulimit_args(cnt, build_args)
     if getattr(args, "no_cache", None):
         build_args.append("--no-cache")

--- a/pytests/test_container_to_args.py
+++ b/pytests/test_container_to_args.py
@@ -1,0 +1,58 @@
+from unittest import mock
+from podman_compose import container_to_args
+
+
+def create_compose_mock():
+    compose = mock.Mock()
+    compose.project_name = "test_project_name"
+    compose.dirname = "test_dirname"
+    compose.container_names_by_service.get = mock.Mock(return_value=None)
+    compose.prefer_volume_over_mount = False
+    compose.default_net = None
+    compose.networks = {}
+    return compose
+
+
+def get_minimal_container():
+    return {
+        "name": "project_name_service_name1",
+        "service_name": "service_name",
+        "image": "busybox",
+    }
+
+
+def test_container_to_args_minimal() -> None:
+    c = create_compose_mock()
+
+    cnt = get_minimal_container()
+
+    args = container_to_args(c, cnt)
+    assert args == [
+        "--name=project_name_service_name1",
+        "-d",
+        "--net",
+        "",
+        "--network-alias",
+        "service_name",
+        "busybox",
+    ]
+
+
+def test_container_to_args_runtime() -> None:
+    c = create_compose_mock()
+
+    cnt = get_minimal_container()
+    cnt["runtime"] = "runsc"
+
+    args = container_to_args(c, cnt)
+    assert args == [
+        "--name=project_name_service_name1",
+        "-d",
+        "--net",
+        "",
+        "--network-alias",
+        "service_name",
+        "--runtime",
+        "runsc",
+        "busybox",
+    ]

--- a/tests/additional_contexts/README.md
+++ b/tests/additional_contexts/README.md
@@ -1,0 +1,14 @@
+# Test podman-compose with build.additional_contexts
+
+```
+podman-compose build
+podman-compose up
+podman-compose down
+```
+
+expected output would be
+
+```
+[dict] | Data for dict
+[list] | Data for list
+```

--- a/tests/additional_contexts/data_for_dict/data.txt
+++ b/tests/additional_contexts/data_for_dict/data.txt
@@ -1,0 +1,1 @@
+Data for dict

--- a/tests/additional_contexts/data_for_list/data.txt
+++ b/tests/additional_contexts/data_for_list/data.txt
@@ -1,0 +1,1 @@
+Data for list

--- a/tests/additional_contexts/project/Dockerfile
+++ b/tests/additional_contexts/project/Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox
+COPY --from=data data.txt /data/data.txt
+CMD ["busybox", "cat", "/data/data.txt"]

--- a/tests/additional_contexts/project/docker-compose.yml
+++ b/tests/additional_contexts/project/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "3.7"
+services:
+  dict:
+    build:
+      context: .
+      additional_contexts:
+        data: ../data_for_dict
+  list:
+    build:
+      context: .
+      additional_contexts:
+        - data=../data_for_list

--- a/tests/build_secrets/Dockerfile
+++ b/tests/build_secrets/Dockerfile
@@ -1,0 +1,9 @@
+FROM busybox
+
+RUN --mount=type=secret,required=true,id=build_secret \
+    ls -l /run/secrets/ && cat /run/secrets/build_secret
+
+RUN --mount=type=secret,required=true,id=build_secret,target=/tmp/secret \
+    ls -l /run/secrets/ /tmp/ && cat /tmp/secret
+
+CMD [ 'echo', 'nothing here' ]

--- a/tests/build_secrets/docker-compose.yaml
+++ b/tests/build_secrets/docker-compose.yaml
@@ -1,0 +1,22 @@
+version: "3.8"
+
+services:
+  test:
+    image: test
+    secrets:
+      - run_secret                  # implicitly mount to /run/secrets/run_secret
+      - source: run_secret
+        target: /tmp/run_secret2    # explicit mount point
+
+    build:
+      context: .
+      secrets:
+        - build_secret              # can be mounted in Dockefile with "RUN --mount=type=secret,id=build_secret"
+        - source: build_secret
+          target: build_secret2     # rename to build_secret2
+
+secrets:
+  build_secret:
+    file: ./my_secret
+  run_secret:
+    file: ./my_secret

--- a/tests/build_secrets/docker-compose.yaml.invalid
+++ b/tests/build_secrets/docker-compose.yaml.invalid
@@ -1,0 +1,18 @@
+version: "3.8"
+
+services:
+  test:
+    image: test
+    build:
+      context: .
+      secrets:
+        # invalid target argument
+        #
+        # According to https://github.com/compose-spec/compose-spec/blob/master/build.md, target is
+        # supposed to be the "name of a *file* to be mounted in /run/secrets/". Not a path.
+        - source: build_secret
+          target: /build_secret
+
+secrets:
+  build_secret:
+    file: ./my_secret

--- a/tests/build_secrets/my_secret
+++ b/tests/build_secrets/my_secret
@@ -1,0 +1,1 @@
+important-secret-is-important

--- a/tests/env-file-tests/README.md
+++ b/tests/env-file-tests/README.md
@@ -7,3 +7,9 @@ podman-compose -f project/container-compose.yaml --env-file env-files/project-1.
 ```
 podman-compose -f $(pwd)/project/container-compose.yaml --env-file $(pwd)/env-files/project-1.env up
 ```
+
+based on environment variable precedent this command should give podman-rocks-321
+
+```
+ZZVAR1=podman-rocks-321 podman-compose -f $(pwd)/project/container-compose.yaml --env-file $(pwd)/env-files/project-1.env up
+```

--- a/tests/pid/docker-compose.yml
+++ b/tests/pid/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  serv:
+    image: busybox
+    pid: host
+    command: sh -c "ps all"

--- a/tests/test_podman_compose_build_secrets.py
+++ b/tests/test_podman_compose_build_secrets.py
@@ -1,0 +1,79 @@
+"""Test how secrets in files are passed to podman.
+"""
+import os
+import subprocess
+import pytest
+
+
+@pytest.fixture(name="compose_yaml_path")
+def fixture_compose_yaml_path(test_path):
+    """ "Returns the path to the compose file used for this test module"""
+    return os.path.join(test_path, "build_secrets")
+
+
+def test_run_secret(podman_compose_path, compose_yaml_path):
+    """podman run should receive file secrets as --volume
+
+    See build_secrets/docker-compose.yaml for secret names and mount points (aka targets)
+
+    """
+    # This command *will* eventually fail with an AttributeError exception (maybe a bug related to
+    # "--dry-run"?), but it prints the arguments that would be passed to podman, which is sufficient
+    # for this test
+    cmd = (
+        podman_compose_path,
+        "--dry-run",
+        "-f",
+        os.path.join(compose_yaml_path, "docker-compose.yaml"),
+        "run",
+        "test",
+    )
+    p = subprocess.run(
+        cmd, stdout=subprocess.PIPE, check=False, stderr=subprocess.STDOUT, text=True
+    )
+    secret_path = os.path.join(compose_yaml_path, "my_secret")
+    assert (
+        f"--volume {secret_path}:/run/secrets/run_secret:ro,rprivate,rbind" in p.stdout
+    )
+    assert f"--volume {secret_path}:/tmp/run_secret2:ro,rprivate,rbind" in p.stdout
+
+
+def test_build_secret(podman_compose_path, compose_yaml_path):
+    """podman build should receive secrets as --secret, so that they can be used inside the
+    Dockerfile in "RUN --mount=type=secret ..." commands.
+
+    """
+    cmd = (
+        podman_compose_path,
+        "--dry-run",
+        "-f",
+        os.path.join(compose_yaml_path, "docker-compose.yaml"),
+        "build",
+    )
+    p = subprocess.run(
+        cmd, stdout=subprocess.PIPE, check=False, stderr=subprocess.STDOUT, text=True
+    )
+    secret_path = os.path.join(compose_yaml_path, "my_secret")
+    assert f"--secret id=build_secret,src={secret_path}" in p.stdout
+    assert f"--secret id=build_secret2,src={secret_path}" in p.stdout
+
+
+def test_invalid_build_secret(podman_compose_path, compose_yaml_path):
+    """build secrets in docker-compose file can only have a target argument without directory
+    component
+
+    """
+    cmd = (
+        podman_compose_path,
+        "--dry-run",
+        "-f",
+        os.path.join(compose_yaml_path, "docker-compose.yaml.invalid"),
+        "build",
+    )
+    p = subprocess.run(
+        cmd, stdout=subprocess.PIPE, check=False, stderr=subprocess.STDOUT, text=True
+    )
+    assert (
+        'ValueError: ERROR: Build secret "build_secret" has invalid target "/build_secret"'
+        in p.stdout
+    )


### PR DESCRIPTION
podman returns unsupported ipam driver "default" when --imap-driver default parameter is passed.

So, when ipam driver is set to "default" in docker-compose.yml, --imap-driver must not be used when podman is called.
